### PR TITLE
update block metadata version

### DIFF
--- a/plugin/src/quic_plugin.rs
+++ b/plugin/src/quic_plugin.rs
@@ -242,7 +242,7 @@ impl GeyserPlugin for QuicGeyserPlugin {
             slot: blockinfo.slot,
             parent_blockhash: blockinfo.parent_blockhash.to_string(),
             blockhash: blockinfo.blockhash.to_string(),
-            rewards: blockinfo.rewards.to_vec(),
+            rewards: blockinfo.rewards.rewards.to_vec(),
             block_height: blockinfo.block_height,
             executed_transaction_count: blockinfo.executed_transaction_count,
             entries_count: blockinfo.entry_count,

--- a/plugin/src/quic_plugin.rs
+++ b/plugin/src/quic_plugin.rs
@@ -231,9 +231,9 @@ impl GeyserPlugin for QuicGeyserPlugin {
             return Ok(());
         };
 
-        let ReplicaBlockInfoVersions::V0_0_3(blockinfo) = blockinfo else {
+        let ReplicaBlockInfoVersions::V0_0_4(blockinfo) = blockinfo else {
             return Err(GeyserPluginError::AccountsUpdateError {
-                msg: "Unsupported account info version".to_string(),
+                msg: "Unsupported block info version".to_string(),
             });
         };
 


### PR DESCRIPTION
in 2.0.18 versions deserializing to `ReplicaBlockInfoVersions::V0_0_3` is giving errors.
```
Failed to update block metadata at slot 305516372, error: Error updating account. Error message: (Unsupported account info version)
```

Updating the ReplicaBlockInfoVersions to v0_0_4 fixes this.